### PR TITLE
Aggiunti test getConfigurazioneComponente e release notes 1.0.2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-05-06  Giuliano Pintori <pintori@link.it>
 
+	* [Test]
+	Aumentata coverage di GdeService da 82.6% a 100%:
+	- test del nuovo metodo getConfigurazioneComponente (null check componente,
+	  null check giornale, mapping di tutti gli 8 valori di ComponenteEvento
+	  e ramo default per valori non gestiti)
+	- test di convertToGdeEvent (UnsupportedOperationException)
+	- test del ramo if di setResponsePayload con ParametriRisposta non null
+
 	* [CI/CD]
 	Fix step "Zip SQL files" del job release: aggiunto mkdir -p target per
 	creare la cartella di output prima dello zip (il job parte da un checkout

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,25 @@
+# Release Notes
+
+## 1.0.2 — 2026-05-06
+
+Release di manutenzione: aggiornamento dipendenze GovPay e potenziamento della pipeline di build/release.
+
+### Aggiornamenti dipendenze
+- `govpay-bom` aggiornato a **1.1.3** (parent BOM).
+- `govpay-common` aggiornato a **1.1.2**.
+
+### Pipeline
+- **SBOM CycloneDX**: aggiunto job `sbom` che genera l'SBOM aggregato (formati `json` + `xml`, schema 1.6) tramite `cyclonedx-maven-plugin`. Eseguito su push su `main`/tag o su richiesta esplicita (`vars.FORCE_SBOM_JOB`); disattivabile con `vars.DISABLE_SBOM_JOB`. L'SBOM viene incluso nel ZIP `release-reports` sotto `reports/sbom/`.
+- **OSV Scanner**: aggiunto job `osv-scan` (Google OSV Scanner) eseguito su `main`/tag con fallimento bloccante. Il report SARIF è incluso nel ZIP `release-reports` sotto `reports/osv/`.
+- **Cache OWASP Dependency-Check**: chiave basata sulla data e flag `NOUPDATE_FLAG` per saltare l'aggiornamento NVD quando la cache è della stessa giornata.
+- **Workflow `refresh-owasp-db`**: aggiornamento notturno della cache NVD per ridurre la latenza dei job di build.
+- **Reports ZIP unico**: tutti i report (OWASP, JaCoCo, OSV, licenze, SBOM) collezionati in `release-reports-<tag>.zip` allegato alla GitHub Release.
+- **Bump action GitHub**: `actions/upload-artifact` e `actions/download-artifact` portati a v7.
+- **Fix step "Zip SQL files"**: aggiunto `mkdir -p target` per creare la cartella di output prima dello zip (il job parte da un checkout pulito senza `target/`).
+
+### Codice
+- `GdeService`: aggiunto override di `getConfigurazioneComponente(ComponenteEvento, Giornale)` per allineamento al nuovo contratto di `AbstractGdeService` introdotto in `govpay-common` 1.1.2 (mapping `ComponenteEvento` → `GdeInterfaccia` tramite i getter del `Giornale`).
+- Aggiunti script SQL di svecchiamento delle tabelle Spring Batch (`spring-batch-cleanup.sql`) per tutti i database supportati (PostgreSQL, MySQL, Oracle, SQL Server, HSQLDB).
+
+### Compatibilità
+Nessuna breaking change. Aggiornamento drop-in rispetto alla 1.0.1.

--- a/src/test/java/it/govpay/rt/batch/unit/service/GdeServiceTest.java
+++ b/src/test/java/it/govpay/rt/batch/unit/service/GdeServiceTest.java
@@ -27,7 +27,12 @@ import it.gov.pagopa.pagopa_api.pa.pafornode.PaSendRTV2Request;
 import it.gov.pagopa.pagopa_api.pa.pafornode.PaSendRTV2Response;
 import it.gov.pagopa.pagopa_api.xsd.common_types.v1_0.StOutcome;
 import it.govpay.common.client.model.Connettore;
+import it.govpay.common.configurazione.model.GdeInterfaccia;
+import it.govpay.common.configurazione.model.Giornale;
 import it.govpay.common.configurazione.service.ConfigurazioneService;
+import it.govpay.common.gde.GdeEventInfo;
+import it.govpay.gde.client.beans.ComponenteEvento;
+import it.govpay.gde.client.beans.DettaglioRisposta;
 import it.govpay.gde.client.beans.EsitoEvento;
 import it.govpay.gde.client.beans.NuovoEvento;
 import it.govpay.rt.batch.dto.RtRetrieveContext;
@@ -208,6 +213,106 @@ class GdeServiceTest {
             verify(eventoRtMapper).setParametriRichiesta(eq(mockEvento), eq(GOVPAY_URL), eq("POST"), anyList());
             verify(eventoRtMapper).setParametriRispostaSoap(eq(mockEvento), eq(dataEnd), eq(response), anyList());
             verify(gdeRestTemplate).postForEntity(eq(GDE_ENDPOINT), eq(mockEvento), eq(Void.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("convertToGdeEvent")
+    class ConvertToGdeEventTest {
+
+        @Test
+        @DisplayName("should throw UnsupportedOperationException")
+        void shouldThrowUnsupportedOperationException() {
+            UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                    () -> ReflectionTestUtils.invokeMethod(gdeService, "convertToGdeEvent",
+                            (GdeEventInfo) null));
+            assertTrue(ex.getMessage().contains("sendEventAsync"));
+        }
+    }
+
+    @Nested
+    @DisplayName("setResponsePayload")
+    class SetResponsePayloadTest {
+
+        @Test
+        @DisplayName("should invoke setPayload when ParametriRisposta is present")
+        void shouldSetPayloadWhenParametriRispostaPresent() {
+            setupGdeEnabled();
+            ResponseEntity<String> response = ResponseEntity.ok("receipt data");
+            DettaglioRisposta parametriRisposta = spy(new DettaglioRisposta());
+            NuovoEvento mockEvento = new NuovoEvento();
+            mockEvento.setParametriRisposta(parametriRisposta);
+            mockEvento.setEsito(EsitoEvento.OK);
+
+            when(eventoRtMapper.createEventoOk(eq(rtInfo), anyString(), anyString(), eq(dataStart), eq(dataEnd)))
+                    .thenReturn(mockEvento);
+
+            gdeService.saveGetReceiptOk(rtInfo, response, dataStart, dataEnd, PAGOPA_BASE_URL);
+
+            verify(parametriRisposta).setPayload(any());
+            verify(gdeRestTemplate).postForEntity(eq(GDE_ENDPOINT), eq(mockEvento), eq(Void.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getConfigurazioneComponente")
+    class GetConfigurazioneComponenteTest {
+
+        private GdeInterfaccia invoke(ComponenteEvento componente, Giornale giornale) {
+            return ReflectionTestUtils.invokeMethod(gdeService, "getConfigurazioneComponente",
+                    componente, giornale);
+        }
+
+        @Test
+        @DisplayName("should return null when componente is null")
+        void shouldReturnNullWhenComponenteIsNull() {
+            assertNull(invoke(null, new Giornale()));
+        }
+
+        @Test
+        @DisplayName("should return null when giornale is null")
+        void shouldReturnNullWhenGiornaleIsNull() {
+            assertNull(invoke(ComponenteEvento.API_PAGOPA, null));
+        }
+
+        @Test
+        @DisplayName("should map each componente to the matching Giornale getter")
+        void shouldMapEachComponenteToMatchingGetter() {
+            Giornale giornale = new Giornale();
+            GdeInterfaccia apiPagoPA = new GdeInterfaccia();
+            GdeInterfaccia apiEnte = new GdeInterfaccia();
+            GdeInterfaccia apiPagamento = new GdeInterfaccia();
+            GdeInterfaccia apiRagioneria = new GdeInterfaccia();
+            GdeInterfaccia apiBackoffice = new GdeInterfaccia();
+            GdeInterfaccia apiPendenze = new GdeInterfaccia();
+            GdeInterfaccia apiBackendIO = new GdeInterfaccia();
+            GdeInterfaccia apiMaggioliJPPA = new GdeInterfaccia();
+            giornale.setApiPagoPA(apiPagoPA);
+            giornale.setApiEnte(apiEnte);
+            giornale.setApiPagamento(apiPagamento);
+            giornale.setApiRagioneria(apiRagioneria);
+            giornale.setApiBackoffice(apiBackoffice);
+            giornale.setApiPendenze(apiPendenze);
+            giornale.setApiBackendIO(apiBackendIO);
+            giornale.setApiMaggioliJPPA(apiMaggioliJPPA);
+
+            assertSame(apiPagoPA, invoke(ComponenteEvento.API_PAGOPA, giornale));
+            assertSame(apiEnte, invoke(ComponenteEvento.API_ENTE, giornale));
+            assertSame(apiPagamento, invoke(ComponenteEvento.API_PAGAMENTO, giornale));
+            assertSame(apiRagioneria, invoke(ComponenteEvento.API_RAGIONERIA, giornale));
+            assertSame(apiBackoffice, invoke(ComponenteEvento.API_BACKOFFICE, giornale));
+            assertSame(apiPendenze, invoke(ComponenteEvento.API_PENDENZE, giornale));
+            assertSame(apiBackendIO, invoke(ComponenteEvento.API_BACKEND_IO, giornale));
+            assertSame(apiMaggioliJPPA, invoke(ComponenteEvento.API_MAGGIOLI_JPPA, giornale));
+        }
+
+        @Test
+        @DisplayName("should return null for unmapped componente values")
+        void shouldReturnNullForUnmappedComponenti() {
+            Giornale giornale = new Giornale();
+            assertNull(invoke(ComponenteEvento.API_GOVPAY, giornale));
+            assertNull(invoke(ComponenteEvento.GOVPAY, giornale));
+            assertNull(invoke(ComponenteEvento.API_USER, giornale));
         }
     }
 


### PR DESCRIPTION
- Coverage GdeService da 82.6% a 100%: test del nuovo metodo getConfigurazioneComponente, di convertToGdeEvent e del ramo if di setResponsePayload con ParametriRisposta non null.
- Aggiunto RELEASE_NOTES.md con il riepilogo della 1.0.2.