### PR TITLE
Rilascio versione 1.0.3 e rimozione direttive logging.level da applic…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2026-05-12  Giuliano Pintori <pintori@link.it>
+
+	* [Build]
+	Avanzamento versione a 1.0.3
+
+	* [Config]
+	Rimosse le direttive logging.level.* da application.properties
+	(root=INFO, it.govpay.rt.batch=DEBUG, org.springframework.batch=DEBUG,
+	org.springframework.web.client=DEBUG, com.fasterxml.jackson=DEBUG).
+	La configurazione di logging e' demandata al runtime (env, profili
+	dedicati, configurazione esterna). I file di test mantengono la propria
+	configurazione di logging dedicata (application-integration.properties).
+
 2026-05-06  Giuliano Pintori <pintori@link.it>
 
 	* [Test]

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>it.govpay</groupId>
     <artifactId>govpay-rt-batch</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>GovPay RT Batch</name>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,10 +39,3 @@ management.endpoints.web.base-path=/actuator
 management.endpoints.web.exposure.include=health,info,metrics
 management.endpoint.health.show-details=when_authorized
 management.health.db.enabled=true
-
-# Logging configuration
-logging.level.root=INFO
-logging.level.it.govpay.rt.batch=DEBUG
-logging.level.org.springframework.batch=DEBUG
-logging.level.org.springframework.web.client=DEBUG
-logging.level.com.fasterxml.jackson=DEBUG


### PR DESCRIPTION
…ation.properties

Le direttive logging.level.* (incluso com.fasterxml.jackson=DEBUG residuo di debug puntuale) sono state rimosse dal file principale. La configurazione di logging e' ora demandata al runtime (env, profili dedicati, configurazione esterna). I file di test mantengono la propria configurazione di logging dedicata.