### PR TITLE
Docker: curl con -f sul download di sql.zip

### DIFF
--- a/docker/govpay-rt/Dockerfile.github
+++ b/docker/govpay-rt/Dockerfile.github
@@ -37,7 +37,7 @@ curl -fL -o /tmp/govpay-rt-batch.jar "https://github.com/link-it/govpay-rt-batch
 mv /tmp/govpay-rt-batch.jar ${GOVPAY_RT_HOME}/govpay-rt-batch.jar; \
 chown govpay:govpay ${GOVPAY_RT_HOME}/govpay-rt-batch.jar; \
 ls -la ${GOVPAY_RT_HOME}/; \
-curl -kL -sS -q -o /tmp/sql.zip "https://github.com/link-it/govpay-rt-batch/releases/download/${GOVPAY_RT_FULLVERSION}/sql.zip"; \
+curl -fkL -sS -q -o /tmp/sql.zip "https://github.com/link-it/govpay-rt-batch/releases/download/${GOVPAY_RT_FULLVERSION}/sql.zip"; \
 unzip -q /tmp/sql.zip -d /opt && rm /tmp/sql.zip; \
 chown -R govpay:govpay /opt/sql; \
 curl -kL -sS -q -o /var/tmp/hsqldb-${HSQLDB_FULLVERSION}.zip https://sourceforge.net/projects/hsqldb/files/hsqldb/hsqldb_2_7/hsqldb-${HSQLDB_FULLVERSION}.zip/download; \


### PR DESCRIPTION
Difetto preesistente nel percorso Docker di produzione, emerso durante l'allineamento della pipeline.

## `curl` senza `-f` sul download di `sql.zip`

`Dockerfile.github` scaricava `sql.zip` dagli asset della release con `curl -kL -sS -q`, **senza `-f`**. Senza quel flag curl esce **0** anche su un 404 e scrive il corpo della risposta di errore nel file di destinazione. La riga successiva, `unzip -q /tmp/sql.zip`, falliva su un file che non è uno zip — e poiché il blocco è in `RUN set -eux`, il build si interrompeva con un errore di `unzip` incomprensibile invece di un chiaro fallimento sul download.

È il motivo per cui il problema è rimasto invisibile: il sintomo indicava lo unzip, la causa era l'asset mancante.

Con `-f` curl fallisce subito e il messaggio nomina l'asset. Nessun cambiamento di comportamento quando l'asset è presente.

*Fuori scope*: la riga che scarica il jar poco sopra usa anch'essa `curl -kL` senza `-f`, ma il jar viene immediatamente ri-scaricato con `curl -fL` e sovrascritto, quindi il caso è già coperto. Non modificata.

## Portata

Il difetto era su **tutti e sei i batch**, corretto in ognuno. In `govpay-notify-batch` e `govpay-maggioli-jppa` la PR corrispondente contiene anche il DDL Spring Batch mancante, che era la causa concreta del 404 su `sql.zip`.

## Verifica

- `curl -f`: comportamento invariato con asset presente; su asset mancante il build ora fallisce sul download con messaggio esplicito.
- **Il percorso di produzione resta non collaudato**: `release` e `docker` girano solo sui tag e non sono mai stati eseguiti qui. La verifica vera è il primo tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
