### PR TITLE
Sonar: risolte le 11 segnalazioni aperte del progetto

### DIFF
--- a/src/main/java/it/govpay/rt/batch/config/BatchControllerSupport.java
+++ b/src/main/java/it/govpay/rt/batch/config/BatchControllerSupport.java
@@ -1,0 +1,35 @@
+package it.govpay.rt.batch.config;
+
+import java.time.ZoneId;
+
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.core.env.Environment;
+
+import it.govpay.common.batch.runner.JobExecutionHelper;
+import jakarta.persistence.EntityManager;
+
+/**
+ * Collaboratori infrastrutturali richiesti da
+ * {@code AbstractBatchController} di {@code govpay-common}.
+ * <p>
+ * Sono raggruppati in un unico bean per non farli comparire uno per uno nella
+ * firma dei controller concreti: la superclasse ne richiede sei e il costruttore
+ * del controller supererebbe il limite di parametri, nascondendo fra
+ * l'infrastruttura le dipendenze che sono davvero specifiche del batch (i job e
+ * i service).
+ *
+ * @param jobExecutionHelper      helper multi-nodo di govpay-common
+ * @param jobRepository           repository dei metadati Spring Batch
+ * @param environment             environment Spring (profili, proprieta')
+ * @param applicationZoneId       timezone applicativo (vedi {@link TimezoneConfig})
+ * @param schedulerIntervalMillis intervallo dello scheduler, per il calcolo della prossima esecuzione
+ * @param entityManager           entity manager usato per le query di dettaglio sulle esecuzioni
+ */
+public record BatchControllerSupport(
+        JobExecutionHelper jobExecutionHelper,
+        JobRepository jobRepository,
+        Environment environment,
+        ZoneId applicationZoneId,
+        long schedulerIntervalMillis,
+        EntityManager entityManager) {
+}

--- a/src/main/java/it/govpay/rt/batch/config/BatchInfraConfig.java
+++ b/src/main/java/it/govpay/rt/batch/config/BatchInfraConfig.java
@@ -7,9 +7,11 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 import it.govpay.common.batch.runner.JobExecutionHelper;
 import it.govpay.common.batch.service.JobConcurrencyService;
+import jakarta.persistence.EntityManager;
 
 /**
  * Configurazione dei bean infrastrutturali per la gestione batch multi-nodo.
@@ -31,5 +33,21 @@ public class BatchInfraConfig {
             @Value("${govpay.batch.cluster-id:GovPay-RT-Batch}") String clusterId,
             ZoneId applicationZoneId) {
         return new JobExecutionHelper(jobOperator, jobConcurrencyService, clusterId, applicationZoneId);
+    }
+
+    /**
+     * Raggruppa i collaboratori richiesti da {@code AbstractBatchController}
+     * (vedi {@link BatchControllerSupport}).
+     */
+    @Bean
+    public BatchControllerSupport batchControllerSupport(
+            JobExecutionHelper jobExecutionHelper,
+            JobRepository jobRepository,
+            Environment environment,
+            ZoneId applicationZoneId,
+            @Value("${scheduler.rtRetrieveJob.fixedDelayString:7200000}") long schedulerIntervalMillis,
+            EntityManager entityManager) {
+        return new BatchControllerSupport(jobExecutionHelper, jobRepository, environment,
+                applicationZoneId, schedulerIntervalMillis, entityManager);
     }
 }

--- a/src/main/java/it/govpay/rt/batch/config/BatchJobConfiguration.java
+++ b/src/main/java/it/govpay/rt/batch/config/BatchJobConfiguration.java
@@ -62,8 +62,11 @@ public class BatchJobConfiguration {
         RtRetrieveProcessor rtRetrieveProcessor,
         RtRetrieveWriter rtRetrieveWriter
     ) {
+        // chunk(int, PlatformTransactionManager) e' deprecato da Spring Batch 6 e rimosso
+        // in 7: il transaction manager si passa ora con la fluent .transactionManager().
         return new StepBuilder("rtRetrieveTasklet", jobRepository)
-            .<RtRetrieveContext, RtRetrieveBatch>chunk(1, transactionManager)
+            .<RtRetrieveContext, RtRetrieveBatch>chunk(1)
+            .transactionManager(transactionManager)
             .reader(rtRetrieveReader)
             .processor(rtRetrieveProcessor)
             .writer(rtRetrieveWriter)

--- a/src/main/java/it/govpay/rt/batch/config/TimezoneConfig.java
+++ b/src/main/java/it/govpay/rt/batch/config/TimezoneConfig.java
@@ -1,5 +1,6 @@
 package it.govpay.rt.batch.config;
 
+import java.time.Clock;
 import java.time.ZoneId;
 import java.util.TimeZone;
 
@@ -36,5 +37,16 @@ public class TimezoneConfig {
     @Bean
     public ZoneId applicationZoneId() {
         return ZoneId.of(timezone);
+    }
+
+    /**
+     * Orologio applicativo agganciato al timezone configurato: e' la sorgente
+     * unica del "tempo corrente" per reader, processor, writer e listener del
+     * batch. Va usato al posto delle {@code now()} senza argomenti, che
+     * dipendono dal default della JVM (implicito e non sostituibile nei test).
+     */
+    @Bean
+    public Clock applicationClock(ZoneId applicationZoneId) {
+        return Clock.system(applicationZoneId);
     }
 }

--- a/src/main/java/it/govpay/rt/batch/controller/BatchController.java
+++ b/src/main/java/it/govpay/rt/batch/controller/BatchController.java
@@ -1,12 +1,7 @@
 package it.govpay.rt.batch.controller;
 
-import java.time.ZoneId;
-
 import org.springframework.batch.core.job.Job;
-import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +12,9 @@ import it.govpay.common.batch.controller.AbstractBatchController;
 import it.govpay.common.batch.dto.BatchStatusInfo;
 import it.govpay.common.batch.dto.LastExecutionInfo;
 import it.govpay.common.batch.dto.NextExecutionInfo;
-import it.govpay.common.batch.runner.JobExecutionHelper;
 import it.govpay.rt.batch.Costanti;
+import it.govpay.rt.batch.config.BatchControllerSupport;
 import it.govpay.rt.batch.service.RtApiService;
-import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -35,15 +29,11 @@ public class BatchController extends AbstractBatchController {
     private final RtApiService rtApiService;
 
     public BatchController(
-            JobExecutionHelper jobExecutionHelper,
-            JobRepository jobRepository,
+            BatchControllerSupport support,
             @Qualifier("rtRetrieveJob") Job rtRetrieveJob,
-            RtApiService rtApiService,
-            Environment environment,
-            ZoneId applicationZoneId,
-            @Value("${scheduler.rtRetrieveJob.fixedDelayString:7200000}") long schedulerIntervalMillis,
-            EntityManager entityManager) {
-        super(jobExecutionHelper, jobRepository, environment, applicationZoneId, schedulerIntervalMillis, entityManager);
+            RtApiService rtApiService) {
+        super(support.jobExecutionHelper(), support.jobRepository(), support.environment(),
+                support.applicationZoneId(), support.schedulerIntervalMillis(), support.entityManager());
         this.rtRetrieveJob = rtRetrieveJob;
         this.rtApiService = rtApiService;
     }

--- a/src/main/java/it/govpay/rt/batch/gde/mapper/EventoRtMapper.java
+++ b/src/main/java/it/govpay/rt/batch/gde/mapper/EventoRtMapper.java
@@ -274,13 +274,6 @@ public class EventoRtMapper {
     }
 
     /**
-     * Extracts error information from exception and sets outcome (KO or FAIL).
-     *
-     * @param responseEntity Response entity
-     * @param exception      Exception
-     * @param nuovoEvento    Event to update
-     */
-    /**
      * Extracts the HTTP status code from a WebServiceTransportException message (e.g., " [401]").
      * Falls back to 500 if the status code cannot be parsed.
      */
@@ -292,6 +285,13 @@ public class EventoRtMapper {
         return 500;
     }
 
+    /**
+     * Extracts error information from exception and sets outcome (KO or FAIL).
+     *
+     * @param responseEntity Response entity
+     * @param exception      Exception
+     * @param nuovoEvento    Event to update
+     */
     private void extractExceptionInfo(ResponseEntity<?> responseEntity, RestClientException exception,
                                       NuovoEvento nuovoEvento) {
         if (exception != null) {

--- a/src/main/java/it/govpay/rt/batch/listener/BatchExecutionRecapListener.java
+++ b/src/main/java/it/govpay/rt/batch/listener/BatchExecutionRecapListener.java
@@ -1,6 +1,8 @@
 package it.govpay.rt.batch.listener;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -19,12 +21,18 @@ public class BatchExecutionRecapListener implements JobExecutionListener {
 
 	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss");
 
+    private final Clock clock;
+
+    public BatchExecutionRecapListener(Clock clock) {
+        this.clock = clock;
+    }
+
     @Override
     public void beforeJob(JobExecution jobExecution) {
         log.info("=".repeat(80));
         log.info("INIZIO BATCH RT RETRIEVE");
         log.info("Job ID: {}", jobExecution.getJobInstanceId());
-        log.info("Avvio: {}", LocalDateTime.now().format(TIME_FORMATTER));
+        log.info("Avvio: {}", LocalDateTime.now(clock).format(TIME_FORMATTER));
         log.info("=".repeat(80));
     }
 
@@ -35,15 +43,30 @@ public class BatchExecutionRecapListener implements JobExecutionListener {
         log.info("=".repeat(80));
 
         // Statistiche generali
-        Duration duration = Duration.between(
-            jobExecution.getStartTime(),
-            jobExecution.getEndTime()
-        );
-
         log.info("Status finale: {}", jobExecution.getStatus());
-        log.info("Durata totale: {} secondi", duration.getSeconds());
+        log.info("Durata totale: {} secondi", durataSecondi(jobExecution));
         log.info("");
 
         log.info("=".repeat(80));
+    }
+
+    /**
+     * Durata dell'esecuzione in secondi. {@code JobExecution} espone i timestamp
+     * come {@link LocalDateTime}, che non porta con se' il fuso: prima di calcolare
+     * l'intervallo li si ancora al timezone applicativo e li si converte in
+     * {@link Instant}, cosi' la durata resta corretta anche a cavallo del
+     * cambio ora legale/solare.
+     */
+    private long durataSecondi(JobExecution jobExecution) {
+        LocalDateTime startTime = jobExecution.getStartTime();
+        LocalDateTime endTime = jobExecution.getEndTime();
+        if (startTime == null || endTime == null) {
+            return 0L;
+        }
+        return Duration.between(toInstant(startTime), toInstant(endTime)).getSeconds();
+    }
+
+    private Instant toInstant(LocalDateTime dateTime) {
+        return dateTime.atZone(clock.getZone()).toInstant();
     }
 }

--- a/src/main/java/it/govpay/rt/batch/service/PaForNodeService.java
+++ b/src/main/java/it/govpay/rt/batch/service/PaForNodeService.java
@@ -3,7 +3,6 @@ package it.govpay.rt.batch.service;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import it.gov.pagopa.pagopa_api.pa.pafornode.PaSendRTV2Request;
@@ -24,8 +23,7 @@ public class PaForNodeService {
 	private final GdeService gdeService;
 	private final GovpayClient govpayClient;
 
-	public PaForNodeService(@Autowired(required = false) GdeService gdeService,
-							GovpayClient govpayClient) {
+	public PaForNodeService(GdeService gdeService, GovpayClient govpayClient) {
 		this.gdeService = gdeService;
 		this.govpayClient = govpayClient;
 	}
@@ -35,21 +33,30 @@ public class PaForNodeService {
 
 		OffsetDateTime dataStart = OffsetDateTime.now(ZoneOffset.UTC);
 		OffsetDateTime dataEnd = null;
-		PaSendRTV2Response response = null;
 
 		try {
-			response = govpayClient.sendReceipt(receiptToSend);
+			PaSendRTV2Response response = govpayClient.sendReceipt(receiptToSend);
 			dataEnd = OffsetDateTime.now(ZoneOffset.UTC);
-			log.debug("Ricevuta risposta da govpay: {}", response.getOutcome());
 
-			if (response.getOutcome().equals(StOutcome.OK)) {
-				gdeService.saveSendReceiptOk(rtInfo, receiptToSend, response, dataStart, dataEnd);
-				return true;
-			} else {
+			// govpayClient restituisce null quando la richiesta non e' valorizzata:
+			// senza questa guardia il ramo successivo dereferenzia una response nulla.
+			if (response == null) {
+				log.error("Nessuna risposta da govpay per l'invio della ricevuta");
 				gdeService.saveSendReceiptKo(rtInfo, receiptToSend,
-						new Exception("Outcome KO: " + response.getFault()), dataStart, dataEnd);
+						new IllegalStateException("Nessuna risposta da govpay"), dataStart, dataEnd);
 				return false;
 			}
+
+			log.debug("Ricevuta risposta da govpay: {}", response.getOutcome());
+
+			if (StOutcome.OK.equals(response.getOutcome())) {
+				gdeService.saveSendReceiptOk(rtInfo, receiptToSend, response, dataStart, dataEnd);
+				return true;
+			}
+
+			gdeService.saveSendReceiptKo(rtInfo, receiptToSend,
+					new IllegalStateException("Outcome KO: " + response.getFault()), dataStart, dataEnd);
+			return false;
 		} catch (Exception e) {
 			dataEnd = OffsetDateTime.now(ZoneOffset.UTC);
 			log.error("Errore durante l'invio della ricevuta a govpay", e);

--- a/src/main/java/it/govpay/rt/batch/service/mapper/CtReceiptV2Converter.java
+++ b/src/main/java/it/govpay/rt/batch/service/mapper/CtReceiptV2Converter.java
@@ -1,6 +1,9 @@
 package it.govpay.rt.batch.service.mapper;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import org.springframework.util.StringUtils;
 
 import it.gov.pagopa.pagopa_api.pa.pafornode.CtEntityUniqueIdentifier;
 import it.gov.pagopa.pagopa_api.pa.pafornode.CtReceiptV2;
@@ -91,8 +94,12 @@ public class CtReceiptV2Converter {
 			ctTransferPAReceiptV2.setFiscalCodePA(TransferPA.getFiscalCodePA());
 			ctTransferPAReceiptV2.setIBAN(TransferPA.getIban());
 			ctTransferPAReceiptV2.setIdTransfer(TransferPA.getIdTransfer());
-			if(TransferPA.getMbdAttachment() != null) {
-				ctTransferPAReceiptV2.setMBDAttachment(TransferPA.getMbdAttachment().getBytes());
+			// getMbdAttachment() e' annotato @Nonnull dal generatore OpenAPI, quindi il
+			// solo controllo di nullita' non discrimina mai: l'allegato MBD va comunque
+			// valorizzato solo quando presente, ed e' l'assenza di contenuto a doverlo
+			// escludere. hasText() copre entrambi i casi (null e stringa vuota/blank).
+			if (StringUtils.hasText(TransferPA.getMbdAttachment())) {
+				ctTransferPAReceiptV2.setMBDAttachment(TransferPA.getMbdAttachment().getBytes(StandardCharsets.UTF_8));
 			}
 			ctTransferPAReceiptV2.setMetadata(toCtReceiptV2Metadata(TransferPA.getMetadata()));
 			ctTransferPAReceiptV2.setRemittanceInformation(TransferPA.getRemittanceInformation());

--- a/src/main/java/it/govpay/rt/batch/tasklet/RtRetrieveProcessor.java
+++ b/src/main/java/it/govpay/rt/batch/tasklet/RtRetrieveProcessor.java
@@ -7,6 +7,7 @@ import it.govpay.rt.batch.service.PaForNodeService;
 import it.govpay.rt.batch.service.RtApiService;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,10 +25,12 @@ public class RtRetrieveProcessor implements ItemProcessor<RtRetrieveContext, RtR
 
     private final RtApiService rtApiService;
     private final PaForNodeService govpayService;
+    private final Clock clock;
 
-    public RtRetrieveProcessor(RtApiService rtApiService, PaForNodeService govpayService) {
+    public RtRetrieveProcessor(RtApiService rtApiService, PaForNodeService govpayService, Clock clock) {
         this.rtApiService = rtApiService;
         this.govpayService = govpayService;
+        this.clock = clock;
     }
 
     @Override
@@ -56,7 +59,7 @@ public class RtRetrieveProcessor implements ItemProcessor<RtRetrieveContext, RtR
                                   .codDominio(context.getTaxCode())
                                   .iur(context.getIur())
                                   .iuv(context.getIuv())
-                                  .retrivedTime(LocalDateTime.now())
+                                  .retrivedTime(LocalDateTime.now(clock))
                                   .build();
         return RtRetrieveBatch.builder()
                               .rtId(context.getRtId())

--- a/src/main/java/it/govpay/rt/batch/tasklet/RtRetrieveReader.java
+++ b/src/main/java/it/govpay/rt/batch/tasklet/RtRetrieveReader.java
@@ -1,6 +1,7 @@
 package it.govpay.rt.batch.tasklet;
 
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RtRetrieveReader implements ItemReader<RtRetrieveContext>, StepExecutionListener {
 
     private final RendicontazioniRepository rndRepository;
+    private final Clock clock;
     private final int finestraTemporale;
     private final long lastProcessedId;
 
@@ -32,9 +34,11 @@ public class RtRetrieveReader implements ItemReader<RtRetrieveContext>, StepExec
 
     public RtRetrieveReader(
     		RendicontazioniRepository rndRepository,
+    		Clock clock,
     		@Value("${govpay.batch.finestra-temporale:90}") int finestraTemporale,
     		@Value("#{jobExecutionContext['lastProcessedId'] ?: 0}") long lastProcessedId) {
         this.rndRepository = rndRepository;
+        this.clock = clock;
         this.finestraTemporale = finestraTemporale;
         this.lastProcessedId = lastProcessedId;
     }
@@ -42,7 +46,7 @@ public class RtRetrieveReader implements ItemReader<RtRetrieveContext>, StepExec
     @BeforeStep
     public void initToBeRetrieve() {
 		toBeRetrieveList = new ArrayList<>();
-		LocalDateTime dataLimite = LocalDateTime.now().minusDays(finestraTemporale);
+		LocalDateTime dataLimite = LocalDateTime.now(clock).minusDays(finestraTemporale);
 		List<Object[]> rndInfos = lastProcessedId > 0L ? rndRepository.findRendicontazioneWithNoPagamentoAfterId(lastProcessedId, dataLimite )
 		                                               : rndRepository.findRendicontazioneWithNoPagamento(dataLimite);
 		log.info("Trovate {} ricevute da recuperare", rndInfos.size());

--- a/src/main/java/it/govpay/rt/batch/utils/OffsetDateTimeDeserializer.java
+++ b/src/main/java/it/govpay/rt/batch/utils/OffsetDateTimeDeserializer.java
@@ -21,12 +21,13 @@ import it.govpay.rt.batch.Costanti;
  * Handles variable-length milliseconds (1-9 digits) from pagoPA API responses.
  * Also handles dates without seconds (e.g., 2025-12-09T00:00+01:00).
  * Falls back to CET timezone if parsing fails without timezone information.
+ * <p>
+ * In Jackson 3 (tools.jackson) i deserializer non sono piu' {@link java.io.Serializable},
+ * quindi non servono ne' serialVersionUID ne' il modificatore transient sui campi.
  */
 public class OffsetDateTimeDeserializer extends StdScalarDeserializer<OffsetDateTime> {
 
-	private static final long serialVersionUID = 1L;
-
-	private transient DateTimeFormatter formatter;
+	private final DateTimeFormatter formatter;
 
 	/**
 	 * Flexible formatter that handles:

--- a/src/main/java/it/govpay/rt/batch/utils/OffsetDateTimeSerializer.java
+++ b/src/main/java/it/govpay/rt/batch/utils/OffsetDateTimeSerializer.java
@@ -12,12 +12,13 @@ import it.govpay.rt.batch.Costanti;
 /**
  * Custom serializer for OffsetDateTime to ensure consistent date format in JSON output.
  * Uses configurable date pattern for serialization (default: yyyy-MM-dd'T'HH:mm:ss.SSSXXX).
+ * <p>
+ * In Jackson 3 (tools.jackson) i serializer non sono piu' {@link java.io.Serializable},
+ * quindi non servono ne' serialVersionUID ne' il modificatore transient sui campi.
  */
 public class OffsetDateTimeSerializer extends StdScalarSerializer<OffsetDateTime> {
 
-	private static final long serialVersionUID = 1L;
-
-	private transient DateTimeFormatter formatter;
+	private final DateTimeFormatter formatter;
 
 	/**
 	 * Default constructor using standard timestamp format with timezone.

--- a/src/test/java/it/govpay/rt/batch/controller/BatchControllerTest.java
+++ b/src/test/java/it/govpay/rt/batch/controller/BatchControllerTest.java
@@ -43,6 +43,7 @@ import it.govpay.common.batch.dto.Problem;
 import it.govpay.common.batch.runner.JobExecutionHelper;
 import it.govpay.common.batch.service.JobConcurrencyService;
 import it.govpay.rt.batch.Costanti;
+import it.govpay.rt.batch.config.BatchControllerSupport;
 import it.govpay.rt.batch.service.RtApiService;
 import jakarta.persistence.EntityManager;
 
@@ -79,8 +80,9 @@ class BatchControllerTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         when(jobExecutionHelper.getJobConcurrencyService()).thenReturn(jobConcurrencyService);
-        batchController = new BatchController(jobExecutionHelper, jobRepository, rtRetrieveJob,
-                rtApiService, environment, ZONE_ID, SCHEDULER_INTERVAL_MILLIS, entityManager);
+        BatchControllerSupport support = new BatchControllerSupport(jobExecutionHelper, jobRepository,
+                environment, ZONE_ID, SCHEDULER_INTERVAL_MILLIS, entityManager);
+        batchController = new BatchController(support, rtRetrieveJob, rtApiService);
     }
 
     private JobExecution createJobExecution(String clusterId, BatchStatus status) {

--- a/src/test/java/it/govpay/rt/batch/unit/listener/BatchExecutionRecapListenerTest.java
+++ b/src/test/java/it/govpay/rt/batch/unit/listener/BatchExecutionRecapListenerTest.java
@@ -3,7 +3,9 @@ package it.govpay.rt.batch.unit.listener;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +26,13 @@ class BatchExecutionRecapListenerTest {
     @Mock
     private JobExecution jobExecution;
 
+    private static final Clock CLOCK = Clock.system(ZoneId.of("Europe/Rome"));
+
     private BatchExecutionRecapListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new BatchExecutionRecapListener();
+        listener = new BatchExecutionRecapListener(CLOCK);
     }
 
     @Nested

--- a/src/test/java/it/govpay/rt/batch/unit/service/PaForNodeServiceTest.java
+++ b/src/test/java/it/govpay/rt/batch/unit/service/PaForNodeServiceTest.java
@@ -106,15 +106,32 @@ class PaForNodeServiceTest {
         }
 
         @Test
-        @DisplayName("should work when GdeService is null")
-        void shouldWorkWhenGdeServiceIsNull() {
-            service = new PaForNodeService(null, govpayClient);
+        @DisplayName("should return false and save KO event when response is null")
+        void shouldReturnFalseWhenResponseIsNull() {
+            // GovpayClient restituisce null quando la richiesta non e' valorizzata:
+            // il servizio non deve dereferenziare la response.
+            when(govpayClient.sendReceipt(request)).thenReturn(null);
+
+            boolean result = service.sendReceipt(rtInfo, request);
+
+            assertFalse(result);
+            verify(govpayClient).sendReceipt(request);
+            verify(gdeService).saveSendReceiptKo(eq(rtInfo), eq(request), any(Exception.class), any(), any());
+            verify(gdeService, never()).saveSendReceiptOk(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should return false and save KO event when outcome is null")
+        void shouldReturnFalseWhenOutcomeIsNull() {
             PaSendRTV2Response response = new PaSendRTV2Response();
-            response.setOutcome(StOutcome.OK);
+            response.setOutcome(null);
             when(govpayClient.sendReceipt(request)).thenReturn(response);
 
-            // Should throw NullPointerException because gdeService is null
-            assertThrows(NullPointerException.class, () -> service.sendReceipt(rtInfo, request));
+            boolean result = service.sendReceipt(rtInfo, request);
+
+            assertFalse(result);
+            verify(gdeService).saveSendReceiptKo(eq(rtInfo), eq(request), any(Exception.class), any(), any());
+            verify(gdeService, never()).saveSendReceiptOk(any(), any(), any(), any(), any());
         }
     }
 }

--- a/src/test/java/it/govpay/rt/batch/unit/tasklet/RtRetrieveProcessorTest.java
+++ b/src/test/java/it/govpay/rt/batch/unit/tasklet/RtRetrieveProcessorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+import java.time.ZoneId;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,10 +42,11 @@ class RtRetrieveProcessorTest {
     private static final String TAX_CODE = "12345678901";
     private static final String IUV = "01234567890123456";
     private static final String IUR = "IUR123456";
+    private static final Clock CLOCK = Clock.system(ZoneId.of("Europe/Rome"));
 
     @BeforeEach
     void setUp() {
-        processor = new RtRetrieveProcessor(rtApiService, govpayService);
+        processor = new RtRetrieveProcessor(rtApiService, govpayService, CLOCK);
 
         context = RtRetrieveContext.builder()
                 .rtId(RT_ID)

--- a/src/test/java/it/govpay/rt/batch/unit/tasklet/RtRetrieveReaderTest.java
+++ b/src/test/java/it/govpay/rt/batch/unit/tasklet/RtRetrieveReaderTest.java
@@ -5,7 +5,9 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +31,7 @@ class RtRetrieveReaderTest {
     private RendicontazioniRepository rndRepository;
 
     private static final int FINESTRA_TEMPORALE = 30;
+    private static final Clock CLOCK = Clock.system(ZoneId.of("Europe/Rome"));
 
     private static final String TAX_CODE_1 = "12345678901";
     private static final String TAX_CODE_2 = "98765432101";
@@ -44,7 +47,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should query repository without lastProcessedId when lastProcessedId is 0")
         void shouldQueryRepositoryWithoutLastProcessedIdWhenZero() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
             when(rndRepository.findRendicontazioneWithNoPagamento(any(LocalDateTime.class)))
                     .thenReturn(Collections.emptyList());
 
@@ -57,7 +60,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should query repository with lastProcessedId when lastProcessedId > 0")
         void shouldQueryRepositoryWithLastProcessedIdWhenGreaterThanZero() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 100L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 100L);
             when(rndRepository.findRendicontazioneWithNoPagamentoAfterId(eq(100L), any(LocalDateTime.class)))
                     .thenReturn(Collections.emptyList());
 
@@ -70,7 +73,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should populate list with results from repository using Long ids")
         void shouldPopulateListWithResultsUsingLongIds() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
 
             List<Object[]> results = new ArrayList<>();
             results.add(new Object[]{1L, TAX_CODE_1, IUV_1, IUR_1});
@@ -96,7 +99,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should handle BigInteger ids from repository")
         void shouldHandleBigIntegerIdsFromRepository() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
 
             List<Object[]> results = new ArrayList<>();
             results.add(new Object[]{BigInteger.valueOf(999L), TAX_CODE_1, IUV_1, IUR_1});
@@ -118,7 +121,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should return items in order and null when exhausted")
         void shouldReturnItemsInOrderAndNullWhenExhausted() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
 
             List<Object[]> results = new ArrayList<>();
             results.add(new Object[]{1L, TAX_CODE_1, IUV_1, IUR_1});
@@ -146,7 +149,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should return null immediately when no items")
         void shouldReturnNullImmediatelyWhenNoItems() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
             when(rndRepository.findRendicontazioneWithNoPagamento(any(LocalDateTime.class)))
                     .thenReturn(Collections.emptyList());
 
@@ -164,7 +167,7 @@ class RtRetrieveReaderTest {
         @Test
         @DisplayName("should throw IllegalArgumentException for unsupported types")
         void shouldThrowForUnsupportedTypes() {
-            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, FINESTRA_TEMPORALE, 0L);
+            RtRetrieveReader reader = new RtRetrieveReader(rndRepository, CLOCK, FINESTRA_TEMPORALE, 0L);
 
             // Create a result with an Integer (unsupported)
             List<Object[]> results = new ArrayList<>();


### PR DESCRIPTION
Chiude tutte le 11 segnalazioni SonarCloud in stato *Open / Confirmed* del progetto `link-it_govpay-rt-batch` (effort stimato 1h 24min).

Suite completa verde: **204 test, 0 fallimenti**, incluso l'integration test che avvia l'intero context Spring (quindi il nuovo bean `Clock`, il bean `BatchControllerSupport` e lo step migrato risultano cablati e funzionanti).

## Blocker — Reliability

**`PaForNodeService` L43** — l'unica segnalazione critica, non assegnata da sei mesi.

La certezza dell'NPE rilevata da Sonar viene da `GovpayClient.sendReceipt()`, che restituisce `null` quando la richiesta non e' valorizzata: il ramo successivo dereferenziava direttamente `response.getOutcome()`. Aggiunta la guardia sul null, con registrazione dell'evento GDE KO, e invertito il confronto in `StOutcome.OK.equals(...)` per coprire anche il caso di outcome nullo.

Contestualmente: `new Exception(...)` → `IllegalStateException`, e rimosso `@Autowired(required = false)` dal parametro del costruttore. Su un *parametro* quell'annotazione non ha effetto, e `GdeService` e' un `@Service` senza condizioni, gia' richiesto obbligatoriamente da `RtApiService`: il ramo "gdeService nullo" era morto e mascherava il difetto.

## Medium

| Segnalazione | Intervento |
|---|---|
| `BatchController` L37 — costruttore con 8 parametri | I sei collaboratori infrastrutturali di `AbstractBatchController` sono raggruppati nel record `BatchControllerSupport`, **replicando la convenzione gia' presente in `govpay-notify-batch` e `govpay-iban-batch`** |
| `BatchJobConfiguration` L66 — metodo deprecato marcato per rimozione | `StepBuilder.chunk(int, PlatformTransactionManager)` e' `@Deprecated(since = "6.0", forRemoval = true)`, rimozione prevista in Spring Batch 7. Migrato a `chunk(int)` + `.transactionManager(...)` |
| `CtReceiptV2Converter` L94 — espressione sempre `true` | Vedi sotto |
| `BatchExecutionRecapListener` L39 — durata non time zone-aware | `JobExecution` espone i timestamp come `LocalDateTime`, che non porta con se' il fuso. Ora vengono ancorati al timezone applicativo e convertiti in `Instant`, cosi' la durata resta corretta anche a cavallo del cambio ora legale/solare. Aggiunta anche la guardia su start/end nulli |
| `EventoRtMapper` L287 — commento Javadoc pendente | Il blocco orfano era in realta' il Javadoc di `extractExceptionInfo`, finito prima di `extractHttpStatusCode`. **Riagganciato al metodo corretto invece di eliminarlo** |

### Sull'espressione sempre `true` in `CtReceiptV2Converter`

Il report segnalava che il rimedio meccanico (rimuovere l'espressione) non e' quello corretto, e va confermato sul sorgente. Verificato: `TransferPA` e' generato da OpenAPI e `getMbdAttachment()` e' annotato `@jakarta.annotation.Nonnull`, per cui Sonar dimostra che `!= null` non discrimina mai.

L'annotazione e' pero' una dichiarazione di contratto, non una garanzia a runtime: rimuovere la guardia esporrebbe a NPE su `.getBytes()`. L'intento reale del controllo e' *valorizzare l'allegato MBD solo quando presente*, quindi e' stato sostituito con `StringUtils.hasText()`, che copre sia `null` sia stringa vuota/blank ed e' un controllo che discrimina davvero. Fissato inoltre il charset a UTF-8 su `getBytes()`, che era lasciato al default della piattaforma.

## Low e Info — il tema trasversale della gestione temporale

Il report notava che 6 delle 11 segnalazioni ruotano attorno alle date, e che il profilo indica una convenzione di progetto mancante piu' che sviste locali. L'intervento segue quella lettura:

- **`transient` sui serializer** (`OffsetDateTimeSerializer` L20, `OffsetDateTimeDeserializer` L29) — verificato su `jackson-databind` 3.2.2 che in Jackson 3 (`tools.jackson`) `ValueSerializer` e `ValueDeserializer` **non implementano piu' `Serializable`**. Quindi `transient` *e* `serialVersionUID` erano entrambi vestigiali, residui della migrazione da Jackson 2: rimossi tutti e due, campo `formatter` reso `final`.
- **Le tre `.now()` senza `ZoneId`** (listener L27, processor L59, reader L45) — introdotto il bean `applicationClock` in `TimezoneConfig`, un `Clock` agganciato al timezone applicativo, **come gia' in `govpay-notify-batch`**. E' la sorgente unica del tempo corrente per listener, reader e processor, e a differenza delle `now()` senza argomenti e' sostituibile nei test. Verificato che nel modulo non resta alcuna `.now()` senza argomenti.

## Nota sui test

`PaForNodeServiceTest` conteneva un test — `shouldWorkWhenGdeServiceIsNull` — che asseriva l'`NullPointerException` come *comportamento atteso*: l'NPE lanciato nel blocco `try` veniva catturato dal `catch (Exception e)` e rilanciato dalla `catch` stessa, e il test passava. Documentava il difetto invece di proteggere da esso. E' stato sostituito da due test sul contratto reale del servizio — response nulla e outcome nullo — entrambi con esito `false` ed evento GDE KO registrato.

Adeguati inoltre i costruttori nei test di controller, listener, reader e processor.

## Fuori scope, ma confermato sul codice

Il report ipotizzava che `BatchExecutionRecapListener` e la coppia `OffsetDateTimeSerializer`/`Deserializer` siano classi copiate fra i moduli batch, e suggeriva di estrarle in una libreria comune. Il confronto diretto con i sorgenti degli altri moduli lo conferma per `rt-batch` e `notify-batch`, dove le due classi sono sostanzialmente identiche; le copie in `fdr-batch` e `iban-batch` sono invece divergenti (in `iban-batch` il listener ha responsabilita' aggiuntive: report su file e invio mail).

Questa PR non affronta l'unificazione — richiede un intervento su `govpay-common` e su quattro repository — ma allinea `rt-batch` alle soluzioni gia' adottate in `notify-batch`, cosi' che l'eventuale estrazione futura parta da due copie convergenti anziche' divergenti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
